### PR TITLE
FIX: New cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ setup(name='triangle',
       url='http://dzhelil.info/triangle',
       setup_requires=[
           'setuptools>=18.0',
-          'Cython>=0.18'
+          'Cython>=0.23'
       ],
       install_requires=[
           'numpy>=1.7.0',
-          'Cython>=0.18'
+          'Cython>=0.23'
       ],
       ext_modules=[
           Extension('triangle.core',


### PR DESCRIPTION
Error: unknown file type '.pyx' (from 'triangle/core.pyx')

http://stackoverflow.com/questions/34654173/unknown-file-type-error-with-pxd-file
